### PR TITLE
Update dependency version for Clojure 1.7+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/diogo149/lein-edn-validator"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[instaparse "1.3.2"]]
+  :dependencies [[instaparse "1.4.9"]]
   :repl-options {:init-ns leiningen.edn-validator}
   ;; :pedantic? :warn
   :eval-in-leiningen true)


### PR DESCRIPTION
The previous version of the `instaparse` dependency is broken for Clojure 1.7+.
This commit bumps the dependency to the latest `instaparse` version and fixes the issue.